### PR TITLE
Remove a workaround for vello#719

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -2103,8 +2103,7 @@ dependencies = [
 [[package]]
 name = "vello"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc44dd4eb9af6a41551b9a82c93d068bd832693d6f78ab118ad19780d8e1202e"
+source = "git+https://github.com/linebender/vello#0bef4500c3e60ed36747a7e5fadae3907b89ed62"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -2123,8 +2122,7 @@ dependencies = [
 [[package]]
 name = "vello_encoding"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8110c14702a4e17f9200f6e3c4fe05dda5a22bf031ae4feafed4a61429f66fb2"
+source = "git+https://github.com/linebender/vello#0bef4500c3e60ed36747a7e5fadae3907b89ed62"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -2136,8 +2134,7 @@ dependencies = [
 [[package]]
 name = "vello_shaders"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cad02d6f29f2212a6ee382a8fec6f9977d0cceefacf07f8e361607ffe3988d"
+source = "git+https://github.com/linebender/vello#0bef4500c3e60ed36747a7e5fadae3907b89ed62"
 dependencies = [
  "bytemuck",
  "naga",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -40,7 +40,7 @@ ipc-channel = "0.18.3"
 winit = "0.30"
 pollster = "0.3"
 
-vello = "0.3"
+vello = { git = "https://github.com/linebender/vello" }
 parley = "0.2"
 fastrace = { version = "0.7", features = ["enable"] }
 

--- a/src/rust/src/vello_device/default.rs
+++ b/src/rust/src/vello_device/default.rs
@@ -290,22 +290,12 @@ impl DeviceDriver for VelloGraphicsDevice {
 
         let scale = (size.0 / pixels.0 as f64, size.1 / pixels.1 as f64);
 
-        // when the pixel is small enough, it's not a problem, but if it's
-        // large, this needs a tweak.
-        let with_extended_edge = scale.0 > 1.0 || scale.1 > 1.0;
-
-        #[cfg(debug_assertions)]
-        {
-            savvy::r_eprintln!("with_extended_edge : {with_extended_edge}");
-        }
-
         let image = convert_to_image(
             raster,
             pixels.0 as usize,
             pixels.1 as usize,
             peniko::Extend::Pad,
             alpha,
-            with_extended_edge,
         );
 
         let window_height = VELLO_APP_PROXY.height.load(Ordering::Relaxed) as f64;
@@ -313,7 +303,7 @@ impl DeviceDriver for VelloGraphicsDevice {
 
         VELLO_APP_PROXY
             .scene
-            .draw_raster(&image, scale, pos.into(), angle, with_extended_edge);
+            .draw_raster(&image, scale, pos.into(), angle);
     }
 
     // TODO


### PR DESCRIPTION
```r
vellogd()
library(grid)
grid.raster(cbind(c("red", "blue"), c("blue", "blue")), width = unit(0.5, "npc"))
dev.off()
```
![image](https://github.com/user-attachments/assets/4a9bb9d1-cbbf-4dae-b560-272ebdaa378c)
