### PR TITLE
Glyph

### DIFF
--- a/src/rust/src/debug_device.rs
+++ b/src/rust/src/debug_device.rs
@@ -215,7 +215,7 @@ impl DeviceDriver for DebugGraphicsDevice {
 
     fn glyph(
         &mut self,
-        glyphs: &[char],
+        glyphs: &[u32],
         x: &[f64],
         y: &[f64],
         fontfile: &str,

--- a/src/rust/src/debug_device.rs
+++ b/src/rust/src/debug_device.rs
@@ -211,6 +211,32 @@ impl DeviceDriver for DebugGraphicsDevice {
         savvy::r_eprintln!("[text] text: {text}");
     }
 
+    fn glyph(
+        &mut self,
+        glyphs: &[char],
+        x: &[f64],
+        y: &[f64],
+        fontfile: &str,
+        index: i32,
+        family: &str,
+        weight: f64,
+        style: i32,
+    ) {
+        add_tracing_point!();
+        savvy::r_eprintln!(
+            "[glyph]
+glyphs: {glyphs:?}
+x: {x:?}
+y: {y:?}
+fontfile: {fontfile}
+index: {index}
+family: {family}
+weight: {weight}
+style: {style}
+"
+        );
+    }
+
     fn on_exit(&mut self, _: DevDesc) {
         add_tracing_point!();
         savvy::r_eprintln!("[on_exit]");

--- a/src/rust/src/debug_device.rs
+++ b/src/rust/src/debug_device.rs
@@ -1,3 +1,5 @@
+use std::os::raw::c_uint;
+
 use crate::add_tracing_point;
 use crate::graphics::DeviceDriver;
 
@@ -221,18 +223,26 @@ impl DeviceDriver for DebugGraphicsDevice {
         family: &str,
         weight: f64,
         style: i32,
+        angle: f64,
+        size: f64,
+        colour: c_uint,
     ) {
         add_tracing_point!();
+
+        let fontfile = std::fs::canonicalize(fontfile);
         savvy::r_eprintln!(
             "[glyph]
 glyphs: {glyphs:?}
 x: {x:?}
 y: {y:?}
-fontfile: {fontfile}
+fontfile: {fontfile:?}
 index: {index}
 family: {family}
 weight: {weight}
 style: {style}
+angle: {angle}
+size: {size}
+colour: {colour}
 "
         );
     }

--- a/src/rust/src/graphics/device_driver.rs
+++ b/src/rust/src/graphics/device_driver.rs
@@ -1,6 +1,6 @@
 use savvy::ffi::SEXP;
-use std::ffi::CString;
 use std::slice;
+use std::{ffi::CString, os::raw::c_uint};
 use vellogd_shared::{
     ffi::{
         pDevDesc, pGEcontext, DevDesc, GEaddDevice2, GEcreateDevDesc, GEinitDisplayList,
@@ -270,6 +270,9 @@ pub trait DeviceDriver: std::marker::Sized {
         family: &str,
         weight: f64,
         style: i32,
+        angle: f64,
+        size: f64,
+        colour: c_uint,
     ) {
     }
 
@@ -762,7 +765,7 @@ pub trait DeviceDriver: std::marker::Sized {
             y: *mut f64,
             font: SEXP,
             size: f64,
-            colour: c_int,
+            colour: c_uint,
             rot: f64,
             dd: pDevDesc,
         ) {
@@ -793,7 +796,9 @@ pub trait DeviceDriver: std::marker::Sized {
             let weight = R_GE_glyphFontWeight(font);
             let style = R_GE_glyphFontStyle(font);
 
-            data.glyph(glyphs, x, y, fontfile, index, family, weight, style);
+            data.glyph(
+                glyphs, x, y, fontfile, index, family, weight, style, rot, size, colour,
+            );
         }
 
         //

--- a/src/rust/src/graphics/device_driver.rs
+++ b/src/rust/src/graphics/device_driver.rs
@@ -4,10 +4,13 @@ use std::slice;
 use vellogd_shared::{
     ffi::{
         pDevDesc, pGEcontext, DevDesc, GEaddDevice2, GEcreateDevDesc, GEinitDisplayList,
-        R_CheckDeviceAvailable, R_EmptyEnv, R_GE_capability_glyphs, R_GE_checkVersionOrDie,
-        R_GE_gcontext, R_GE_glyphFontFamily, R_GE_glyphFontFile, R_GE_glyphFontIndex,
-        R_GE_glyphFontStyle, R_GE_glyphFontWeight, R_GE_version, R_NilValue, Rboolean,
-        Rboolean_FALSE, Rboolean_TRUE, Rf_ScalarInteger, SET_VECTOR_ELT,
+        R_CheckDeviceAvailable, R_EmptyEnv, R_GE_capability_clippingPaths,
+        R_GE_capability_compositing, R_GE_capability_glyphs, R_GE_capability_masks,
+        R_GE_capability_paths, R_GE_capability_patterns, R_GE_capability_transformations,
+        R_GE_checkVersionOrDie, R_GE_gcontext, R_GE_glyphFontFamily, R_GE_glyphFontFile,
+        R_GE_glyphFontIndex, R_GE_glyphFontStyle, R_GE_glyphFontWeight, R_GE_version, R_NilValue,
+        Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_allocVector, Rf_protect, Rf_unprotect, INTEGER,
+        INTSXP, SET_VECTOR_ELT,
     },
     text_layouter::TextMetric,
 };
@@ -254,6 +257,9 @@ pub trait DeviceDriver: std::marker::Sized {
     ) {
     }
 
+    /// A callback function to draw a glyph.
+    ///
+    /// cf. https://www.stat.auckland.ac.nz/~paul/Reports/Typography/glyphs/glyphs.html
     fn glyph(
         &mut self,
         glyphs: &[char],
@@ -297,8 +303,68 @@ pub trait DeviceDriver: std::marker::Sized {
     // i32 here.
     fn eventHelper(&mut self, dd: DevDesc, code: i32) {}
 
+    /// cf. src/library/grDevices/src/devices.c in R's source code
     fn capabilities(cap: SEXP) -> SEXP {
-        unsafe { SET_VECTOR_ELT(cap, R_GE_capability_glyphs, Rf_ScalarInteger(1)) };
+        // patterns
+        unsafe {
+            let len = 3;
+            let patterns = Rf_protect(Rf_allocVector(INTSXP, len));
+            std::ptr::write_bytes(INTEGER(patterns), 0, len);
+            // *INTEGER(patterns) = 1;
+            SET_VECTOR_ELT(cap, R_GE_capability_patterns, patterns);
+            Rf_unprotect(1);
+        }
+
+        // clipping_paths
+        unsafe {
+            let clipping_paths = Rf_protect(Rf_allocVector(INTSXP, 1));
+            *INTEGER(clipping_paths) = 0;
+            SET_VECTOR_ELT(cap, R_GE_capability_clippingPaths, clipping_paths);
+            Rf_unprotect(1);
+        }
+
+        // masks
+        unsafe {
+            let len = 2;
+            let masks = Rf_protect(Rf_allocVector(INTSXP, len));
+            std::ptr::write_bytes(INTEGER(masks), 0, len);
+            SET_VECTOR_ELT(cap, R_GE_capability_masks, masks);
+            Rf_unprotect(1);
+        }
+
+        // compositing
+        unsafe {
+            let len = 11;
+            let compositing = Rf_protect(Rf_allocVector(INTSXP, len));
+            std::ptr::write_bytes(INTEGER(compositing), 0, len);
+            SET_VECTOR_ELT(cap, R_GE_capability_compositing, compositing);
+            Rf_unprotect(1);
+        }
+
+        // transforms
+        unsafe {
+            let transforms = Rf_protect(Rf_allocVector(INTSXP, 1));
+            *INTEGER(transforms) = 0;
+            SET_VECTOR_ELT(cap, R_GE_capability_transformations, transforms);
+            Rf_unprotect(1);
+        }
+
+        // paths
+        unsafe {
+            let paths = Rf_protect(Rf_allocVector(INTSXP, 1));
+            *INTEGER(paths) = 0;
+            SET_VECTOR_ELT(cap, R_GE_capability_paths, paths);
+            Rf_unprotect(1);
+        }
+
+        // glyphs
+        unsafe {
+            let glyphs = Rf_protect(Rf_allocVector(INTSXP, 1));
+            *INTEGER(glyphs) = 1;
+            SET_VECTOR_ELT(cap, R_GE_capability_glyphs, glyphs);
+            Rf_unprotect(1);
+        }
+
         cap
     }
 
@@ -679,6 +745,12 @@ pub trait DeviceDriver: std::marker::Sized {
             // data.releaseMask(ref_, *dd);
         }
 
+        unsafe extern "C" fn device_driver_releaseGroup<T: DeviceDriver>(ref_: SEXP, dd: pDevDesc) {
+            let data = ((*dd).deviceSpecific as *mut T).as_mut().unwrap();
+            // TODO
+            // data.releaseMask(ref_, *dd);
+        }
+
         unsafe extern "C" fn device_driver_capabilities<T: DeviceDriver>(cap: SEXP) -> SEXP {
             <T>::capabilities(cap)
         }
@@ -940,7 +1012,7 @@ pub trait DeviceDriver: std::marker::Sized {
 
             (*p_dev_desc).defineGroup = None;
             (*p_dev_desc).useGroup = None;
-            (*p_dev_desc).releaseGroup = None;
+            (*p_dev_desc).releaseGroup = Some(device_driver_releaseGroup::<T>);
 
             (*p_dev_desc).stroke = None;
             (*p_dev_desc).fill = None;

--- a/src/rust/src/graphics/device_driver.rs
+++ b/src/rust/src/graphics/device_driver.rs
@@ -262,7 +262,7 @@ pub trait DeviceDriver: std::marker::Sized {
     /// cf. https://www.stat.auckland.ac.nz/~paul/Reports/Typography/glyphs/glyphs.html
     fn glyph(
         &mut self,
-        glyphs: &[char],
+        glyphs: &[u32],
         x: &[f64],
         y: &[f64],
         fontfile: &str,
@@ -760,7 +760,7 @@ pub trait DeviceDriver: std::marker::Sized {
 
         unsafe extern "C" fn device_driver_glyph<T: DeviceDriver>(
             n: c_int,
-            glyphs: *mut c_int,
+            glyphs: *mut c_uint,
             x: *mut f64,
             y: *mut f64,
             font: SEXP,
@@ -771,17 +771,6 @@ pub trait DeviceDriver: std::marker::Sized {
         ) {
             let data = ((*dd).deviceSpecific as *mut T).as_mut().unwrap();
             let glyphs = slice::from_raw_parts(glyphs, n as _);
-
-            // TODO: if any of the glyph is out of the range, do nothing.
-            if glyphs
-                .iter()
-                .any(|i| i.is_negative() || char::from_u32(*i as u32).is_none())
-            {
-                savvy::r_eprintln!("Invalid glyph");
-                return;
-            }
-
-            let glyphs = std::mem::transmute::<&[i32], &[char]>(glyphs);
 
             let x = slice::from_raw_parts(x, n as _);
             let y = slice::from_raw_parts(y, n as _);

--- a/src/rust/src/graphics/device_driver.rs
+++ b/src/rust/src/graphics/device_driver.rs
@@ -5,9 +5,9 @@ use vellogd_shared::{
     ffi::{
         pDevDesc, pGEcontext, DevDesc, GEaddDevice2, GEcreateDevDesc, GEinitDisplayList,
         R_CheckDeviceAvailable, R_EmptyEnv, R_GE_capability_glyphs, R_GE_checkVersionOrDie,
-        R_GE_definitions, R_GE_gcontext, R_GE_glyphFontFamily, R_GE_glyphFontFile,
-        R_GE_glyphFontIndex, R_GE_glyphFontStyle, R_GE_glyphFontWeight, R_GE_version, R_NilValue,
-        Rboolean, Rboolean_FALSE, Rboolean_TRUE, Rf_ScalarInteger, SET_VECTOR_ELT,
+        R_GE_gcontext, R_GE_glyphFontFamily, R_GE_glyphFontFile, R_GE_glyphFontIndex,
+        R_GE_glyphFontStyle, R_GE_glyphFontWeight, R_GE_version, R_NilValue, Rboolean,
+        Rboolean_FALSE, Rboolean_TRUE, Rf_ScalarInteger, SET_VECTOR_ELT,
     },
     text_layouter::TextMetric,
 };

--- a/src/rust/src/vello_device/default.rs
+++ b/src/rust/src/vello_device/default.rs
@@ -1,3 +1,4 @@
+use std::os::raw::c_uint;
 use std::sync::atomic::Ordering;
 
 use super::xy_to_path;
@@ -232,6 +233,29 @@ impl DeviceDriver for VelloGraphicsDevice {
                     .scene
                     .draw_glyph(glyph_run, color, transform);
             }
+        }
+    }
+
+    fn glyph(
+        &mut self,
+        glyphs: &[char],
+        x: &[f64],
+        y: &[f64],
+        fontfile: &str,
+        index: i32,
+        family: &str,
+        weight: f64,
+        style: i32,
+        angle: f64,
+        size: f64,
+        colour: c_uint,
+    ) {
+        let [r, g, b, a] = colour.to_ne_bytes();
+        let color = peniko::Color::rgba8(r, g, b, a);
+
+        match self.register_font(fontfile) {
+            Ok(res) => savvy::r_eprintln!("{res:?}"),
+            Err(e) => savvy::r_eprintln!("{e}"),
         }
     }
 

--- a/src/rust/src/vello_device/default.rs
+++ b/src/rust/src/vello_device/default.rs
@@ -12,6 +12,7 @@ use vellogd_shared::protocol::FillParams;
 use vellogd_shared::protocol::Request;
 use vellogd_shared::protocol::Response;
 use vellogd_shared::protocol::StrokeParams;
+use vellogd_shared::text_layouter::fontface_to_weight_and_style;
 use vellogd_shared::text_layouter::TextLayouter;
 use vellogd_shared::text_layouter::TextMetric;
 use vellogd_shared::winit_app::convert_to_image;
@@ -209,7 +210,8 @@ impl DeviceDriver for VelloGraphicsDevice {
         .to_string();
         let size = (gc.cex * gc.ps) as f32;
         let lineheight = gc.lineheight as f32;
-        self.build_layout(text, &family, gc.fontface, size, lineheight);
+        let (weight, style) = fontface_to_weight_and_style(gc.fontface);
+        self.build_layout(text, &family, weight, style, size, lineheight);
 
         let layout_width = self.layout.width() as f64;
         let window_height = VELLO_APP_PROXY.height.load(Ordering::Relaxed) as f64;
@@ -238,7 +240,7 @@ impl DeviceDriver for VelloGraphicsDevice {
 
     fn glyph(
         &mut self,
-        glyphs: &[char],
+        glyph_ids: &[u32],
         x: &[f64],
         y: &[f64],
         fontfile: &str,
@@ -250,13 +252,31 @@ impl DeviceDriver for VelloGraphicsDevice {
         size: f64,
         colour: c_uint,
     ) {
+        add_tracing_point!();
+
         let [r, g, b, a] = colour.to_ne_bytes();
         let color = peniko::Color::rgba8(r, g, b, a);
+        let weight = parley::FontWeight::new(weight as f32);
+        let style = match style {
+            1 => parley::FontStyle::Normal,        // R_GE_text_style_normal
+            2 => parley::FontStyle::Italic,        // R_GE_text_style_italic
+            3 => parley::FontStyle::Oblique(None), // R_GE_text_style_oblique
+            _ => parley::FontStyle::Normal,        // TODO: unreachable
+        };
 
-        match self.register_font(fontfile) {
-            Ok(res) => savvy::r_eprintln!("{res:?}"),
-            Err(e) => savvy::r_eprintln!("{e}"),
-        }
+        VELLO_APP_PROXY.scene.draw_glyph_raw(
+            glyph_ids,
+            x,
+            y,
+            fontfile,
+            index as u32,
+            family,
+            weight,
+            style,
+            angle.to_radians(),
+            size as f32,
+            color,
+        );
     }
 
     fn raster(

--- a/src/rust/vellogd-server/src/main.rs
+++ b/src/rust/vellogd-server/src/main.rs
@@ -56,17 +56,7 @@ impl SceneRequestHandler {
             } => {
                 self.scene.draw_rect(p0, p1, fill_params, stroke_params);
             }
-            Request::DrawText {
-                pos,
-                text,
-                color,
-                size,
-                lineheight,
-                family,
-                face,
-                angle,
-                hadj,
-            } => {
+            Request::DrawText { .. } => {
                 // TODO: where to store layout?
 
                 // self.build_layout(text, size, lineheight);

--- a/src/rust/vellogd-server/src/main.rs
+++ b/src/rust/vellogd-server/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
     });
 
     let needs_redraw = Arc::new(AtomicBool::new(false));
-    let scene = SceneDrawer::new(y_transform.clone(), needs_redraw.clone());
+    let scene = SceneDrawer::new(y_transform.clone(), height.clone(), needs_redraw.clone());
 
     let request_handler = SceneRequestHandler {
         scene: scene.clone(),

--- a/src/rust/vellogd-shared/src/ffi.rs
+++ b/src/rust/vellogd-shared/src/ffi.rs
@@ -6,12 +6,21 @@ use std::os::raw::{c_char, c_int, c_uint, c_void};
 
 // redefine necessary symbols. If this gets too many, probably I should use
 // savvy-ffi
+
 pub type SEXP = *mut c_void;
 pub type R_xlen_t = usize;
+pub type SEXPTYPE = ::std::os::raw::c_uint;
+
+pub const INTSXP: SEXPTYPE = 13;
+
 extern "C" {
     pub static mut R_NilValue: SEXP;
     pub fn SET_VECTOR_ELT(x: SEXP, i: R_xlen_t, v: SEXP) -> SEXP;
-    pub fn Rf_ScalarInteger(arg1: c_int) -> SEXP;
+
+    pub fn Rf_protect(arg1: SEXP) -> SEXP;
+    pub fn Rf_unprotect(arg1: c_int);
+    pub fn INTEGER(x: SEXP) -> *mut c_int;
+    pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 
 // TODO: do not include GE version

--- a/src/rust/vellogd-shared/src/ffi.rs
+++ b/src/rust/vellogd-shared/src/ffi.rs
@@ -281,7 +281,7 @@ pub struct _DevDesc {
             y: *mut f64,
             font: SEXP,
             size: f64,
-            colour: c_int,
+            colour: c_uint,
             rot: f64,
             dd: pDevDesc,
         ),

--- a/src/rust/vellogd-shared/src/ffi.rs
+++ b/src/rust/vellogd-shared/src/ffi.rs
@@ -296,4 +296,10 @@ extern "C" {
     pub fn GEcreateDevDesc(dev: pDevDesc) -> pGEDevDesc;
     pub fn GEinitDisplayList(dd: pGEDevDesc);
     pub fn GEaddDevice2(arg1: pGEDevDesc, arg2: *const c_char);
+
+    pub fn R_GE_glyphFontFile(glyphFont: SEXP) -> *const c_char;
+    pub fn R_GE_glyphFontIndex(glyphFont: SEXP) -> c_int;
+    pub fn R_GE_glyphFontFamily(glyphFont: SEXP) -> *const c_char;
+    pub fn R_GE_glyphFontWeight(glyphFont: SEXP) -> f64;
+    pub fn R_GE_glyphFontStyle(glyphFont: SEXP) -> c_int;
 }

--- a/src/rust/vellogd-shared/src/ffi.rs
+++ b/src/rust/vellogd-shared/src/ffi.rs
@@ -7,7 +7,7 @@ use std::os::raw::{c_char, c_int, c_uint, c_void};
 // redefine necessary symbols. If this gets too many, probably I should use
 // savvy-ffi
 pub type SEXP = *mut c_void;
-pub type R_xlen_t = isize;
+pub type R_xlen_t = usize;
 extern "C" {
     pub static mut R_NilValue: SEXP;
     pub fn SET_VECTOR_ELT(x: SEXP, i: R_xlen_t, v: SEXP) -> SEXP;
@@ -16,7 +16,6 @@ extern "C" {
 
 // TODO: do not include GE version
 pub const R_GE_version: u32 = 16;
-pub const R_GE_definitions: u32 = 13;
 
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: c_int);
@@ -66,19 +65,19 @@ pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = c_int;
 
 // capabilities
-pub const R_GE_capability_semiTransparency: isize = 0;
-pub const R_GE_capability_transparentBackground: isize = 1;
-pub const R_GE_capability_rasterImage: isize = 2;
-pub const R_GE_capability_capture: isize = 3;
-pub const R_GE_capability_locator: isize = 4;
-pub const R_GE_capability_events: isize = 5;
-pub const R_GE_capability_patterns: isize = 6;
-pub const R_GE_capability_clippingPaths: isize = 7;
-pub const R_GE_capability_masks: isize = 8;
-pub const R_GE_capability_compositing: isize = 9;
-pub const R_GE_capability_transformations: isize = 10;
-pub const R_GE_capability_paths: isize = 11;
-pub const R_GE_capability_glyphs: isize = 12;
+pub const R_GE_capability_semiTransparency: R_xlen_t = 0;
+pub const R_GE_capability_transparentBackground: R_xlen_t = 1;
+pub const R_GE_capability_rasterImage: R_xlen_t = 2;
+pub const R_GE_capability_capture: R_xlen_t = 3;
+pub const R_GE_capability_locator: R_xlen_t = 4;
+pub const R_GE_capability_events: R_xlen_t = 5;
+pub const R_GE_capability_patterns: R_xlen_t = 6;
+pub const R_GE_capability_clippingPaths: R_xlen_t = 7;
+pub const R_GE_capability_masks: R_xlen_t = 8;
+pub const R_GE_capability_compositing: R_xlen_t = 9;
+pub const R_GE_capability_transformations: R_xlen_t = 10;
+pub const R_GE_capability_paths: R_xlen_t = 11;
+pub const R_GE_capability_glyphs: R_xlen_t = 12;
 
 // style
 pub const R_GE_text_style_normal: u32 = 1;

--- a/src/rust/vellogd-shared/src/ffi.rs
+++ b/src/rust/vellogd-shared/src/ffi.rs
@@ -276,7 +276,7 @@ pub struct _DevDesc {
     pub glyph: Option<
         unsafe extern "C" fn(
             n: c_int,
-            glyphs: *mut c_int,
+            glyphs: *mut c_uint,
             x: *mut f64,
             y: *mut f64,
             font: SEXP,

--- a/src/rust/vellogd-shared/src/ffi.rs
+++ b/src/rust/vellogd-shared/src/ffi.rs
@@ -4,9 +4,14 @@
 
 use std::os::raw::{c_char, c_int, c_uint, c_void};
 
+// redefine necessary symbols. If this gets too many, probably I should use
+// savvy-ffi
 pub type SEXP = *mut c_void;
+pub type R_xlen_t = isize;
 extern "C" {
     pub static mut R_NilValue: SEXP;
+    pub fn SET_VECTOR_ELT(x: SEXP, i: R_xlen_t, v: SEXP) -> SEXP;
+    pub fn Rf_ScalarInteger(arg1: c_int) -> SEXP;
 }
 
 // TODO: do not include GE version
@@ -59,6 +64,26 @@ pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = c_int;
+
+// capabilities
+pub const R_GE_capability_semiTransparency: isize = 0;
+pub const R_GE_capability_transparentBackground: isize = 1;
+pub const R_GE_capability_rasterImage: isize = 2;
+pub const R_GE_capability_capture: isize = 3;
+pub const R_GE_capability_locator: isize = 4;
+pub const R_GE_capability_events: isize = 5;
+pub const R_GE_capability_patterns: isize = 6;
+pub const R_GE_capability_clippingPaths: isize = 7;
+pub const R_GE_capability_masks: isize = 8;
+pub const R_GE_capability_compositing: isize = 9;
+pub const R_GE_capability_transformations: isize = 10;
+pub const R_GE_capability_paths: isize = 11;
+pub const R_GE_capability_glyphs: isize = 12;
+
+// style
+pub const R_GE_text_style_normal: u32 = 1;
+pub const R_GE_text_style_italic: u32 = 2;
+pub const R_GE_text_style_oblique: u32 = 3;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/rust/vellogd-shared/src/text_layouter.rs
+++ b/src/rust/vellogd-shared/src/text_layouter.rs
@@ -1,4 +1,9 @@
-use std::sync::{LazyLock, Mutex};
+use std::{
+    io,
+    sync::{LazyLock, Mutex},
+};
+
+use parley::fontique::{FamilyId, FontInfo};
 
 use crate::ffi::R_GE_gcontext;
 
@@ -90,6 +95,13 @@ pub trait TextLayouter {
                 width: 0.0,
             },
         }
+    }
+
+    fn register_font(&mut self, fontfile: &str) -> io::Result<Vec<(FamilyId, Vec<FontInfo>)>> {
+        let p = std::fs::canonicalize(fontfile).unwrap();
+        let data = std::fs::read(p)?;
+        let mut font_ctx = FONT_CTX.lock().unwrap();
+        Ok(font_ctx.collection.register_fonts(data))
     }
 }
 

--- a/src/rust/vellogd-shared/src/text_layouter.rs
+++ b/src/rust/vellogd-shared/src/text_layouter.rs
@@ -3,8 +3,6 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 
-use parley::fontique::{FamilyId, FontInfo};
-
 use crate::ffi::R_GE_gcontext;
 
 pub struct TextMetric {
@@ -24,7 +22,8 @@ pub trait TextLayouter {
         &mut self,
         text: impl AsRef<str>,
         family: impl AsRef<str>,
-        face: i32,
+        weight: parley::FontWeight,
+        style: parley::FontStyle,
         size: f32,
         lineheight: f32,
     ) {
@@ -42,7 +41,6 @@ pub trait TextLayouter {
             .unwrap_or(parley::GenericFamily::SansSerif.into());
         layout_builder.push_default(family);
 
-        let (weight, style) = fontface_to_weight_and_style(face);
         layout_builder.push_default(parley::StyleProperty::FontWeight(weight));
         layout_builder.push_default(parley::StyleProperty::FontStyle(style));
 
@@ -64,7 +62,8 @@ pub trait TextLayouter {
         }
         .to_string();
         let size = gc.cex * gc.ps;
-        self.build_layout(text, &family, gc.fontface, size as _, gc.lineheight as _);
+        let (weight, style) = fontface_to_weight_and_style(gc.fontface);
+        self.build_layout(text, &family, weight, style, size as _, gc.lineheight as _);
         self.layout_ref().width() as _
     }
 
@@ -77,7 +76,8 @@ pub trait TextLayouter {
         .to_string();
         let size = gc.cex * gc.ps;
         let text = c.to_string();
-        self.build_layout(text, &family, gc.fontface, size as _, gc.lineheight as _);
+        let (weight, style) = fontface_to_weight_and_style(gc.fontface);
+        self.build_layout(text, &family, weight, style, size as _, gc.lineheight as _);
         let layout_ref = self.layout_ref();
         let line = layout_ref.lines().next();
         match line {
@@ -95,13 +95,6 @@ pub trait TextLayouter {
                 width: 0.0,
             },
         }
-    }
-
-    fn register_font(&mut self, fontfile: &str) -> io::Result<Vec<(FamilyId, Vec<FontInfo>)>> {
-        let p = std::fs::canonicalize(fontfile).unwrap();
-        let data = std::fs::read(p)?;
-        let mut font_ctx = FONT_CTX.lock().unwrap();
-        Ok(font_ctx.collection.register_fonts(data))
     }
 }
 


### PR DESCRIPTION
Sample code from https://www.stat.auckland.ac.nz/~paul/Reports/Typography/glyphs/glyphs.html

```r
vellogd()

library(grid)

grid.newpage()

ids <- c(70, 434, 559, 559, 391, 559, 475, 1642, 37, 475, 510, 521)
x <- c(0, 7.5, 15.03125, 20.140625, 25.203125, 33.484375, 38.59375, 42.1875, 45.421875, 55.328125, 58.671875, 66.84375)
y <- rep(0, 12)
fonts <- rep(1:2, c(7, 5))
size <- rep(12, 12)

fontfiles1 <- system.file("fonts", "Montserrat", "static", "Montserrat-BoldItalic.ttf", package="grDevices")
font1 <- glyphFont(fontfiles1, 0, "Montserrat", 700, "italic")
fontfiles2 <- system.file("fonts", "Montserrat", "static", "Montserrat-Medium.ttf", package="grDevices")
font2 <- glyphFont(fontfiles2, 0, "Montserrat", 400, "normal")

width <- 74.46875
height <- 13.11719

rossoCorsa <- "#D40000"
col <- rep(c(rossoCorsa, NA), c(7, 5))
glyphs <- glyphInfo(ids, x, y, fonts, size,
glyphFontList(font1, font2), width, height, col=col)

grid.glyph(glyphs)

dev.off()
```