### PR TITLE
Give up caching on CI on Windows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,6 +50,7 @@ jobs:
           needs: check
 
       - uses: Swatinem/rust-cache@v2
+        if: runner.os != 'Windows'
         with:
           workspaces: src/rust
           prefix-key: "v2-rust"
@@ -58,7 +59,7 @@ jobs:
         with:
           upload-results: 'never'
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
-      
+
       - name: show install log
         if: always()
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src/rust
-          prefix-key: "v2-rust"
+          prefix-key: "v3-rust"
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,7 +50,6 @@ jobs:
           needs: check
 
       - uses: Swatinem/rust-cache@v2
-        if: runner.os != 'Windows'
         with:
           workspaces: src/rust
           prefix-key: "v2-rust"

--- a/configure
+++ b/configure
@@ -51,6 +51,9 @@ fi
 # catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
 if [ "${DEBUG}" = "true" ]; then
   FEATURES="${FEATURES} --features tracing"
+  PROFILE=dev
+else
+  PROFILE=release
 fi
 
 sed \

--- a/configure
+++ b/configure
@@ -48,8 +48,14 @@ else
   FEATURES="--features use_winit"
 fi
 
+# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
+if [ "${DEBUG}" = "true" ]; then
+  FEATURES="${FEATURES} --features tracing"
+fi
+
 sed \
   -e "s/@TARGET@/${TARGET}/" \
+  -e "s/@PROFILE@/${PROFILE}/" \
   -e "s/@FEATURES@/${FEATURES}/" \
   -e "s/@ADDITIONAL_PKG_LIBS@/${ADDITIONAL_PKG_LIBS}/" \
   -e "s|@CARGO_TARGET_DIR@|${CARGO_TARGET_DIR}|" \

--- a/configure.win
+++ b/configure.win
@@ -25,8 +25,15 @@ echo "using Rust compiler: '${RUSTC_VERSION}'"
 if [ -d "${GITHUB_WORKSPACE}" ]; then
   CARGO_TARGET_DIR=$(echo "${GITHUB_WORKSPACE}/src/rust/target" | sed -e 's|\\|/|g') # normalize path
   echo "Detected GitHub Actions envvar. Using ${CARGO_TARGET_DIR} for the target dir of cargo"
+  # always dev build on GitHub Actions CI
+  PROFILE=dev
 else
   CARGO_TARGET_DIR='$(CURDIR)/rust/target'
+  if [ "${DEBUG}" = "true" ]; then
+    PROFILE=dev
+  else
+    PROFILE=release
+  fi
 fi
 
 FEATURES="--features use_winit"
@@ -34,5 +41,6 @@ FEATURES="--features use_winit"
 sed \
   -e "s/@TARGET@/x86_64-pc-windows-gnu/" \
   -e "s/@FEATURES@/${FEATURES}/" \
+  -e "s/@PROFILE@/${PROFILE}/" \
   -e "s|@CARGO_TARGET_DIR@|${CARGO_TARGET_DIR}|" \
   src/Makevars.win.in > src/Makevars.win

--- a/configure.win
+++ b/configure.win
@@ -24,23 +24,18 @@ echo "using Rust compiler: '${RUSTC_VERSION}'"
 # catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
 if [ "${DEBUG}" = "true" ]; then
   FEATURES="--features use_winit --features tracing"
+  PROFILE=dev
 else
   FEATURES="--features use_winit"
+  PROFILE=release
 fi
 
 # In order to use rust-cache action, target dir needs to be a fixed, existing path.
 if [ -d "${GITHUB_WORKSPACE}" ]; then
   CARGO_TARGET_DIR=$(echo "${GITHUB_WORKSPACE}/src/rust/target" | sed -e 's|\\|/|g') # normalize path
   echo "Detected GitHub Actions envvar. Using ${CARGO_TARGET_DIR} for the target dir of cargo"
-  # always dev build on GitHub Actions CI
-  PROFILE=dev
 else
   CARGO_TARGET_DIR='$(CURDIR)/rust/target'
-  if [ "${DEBUG}" = "true" ]; then
-    PROFILE=dev
-  else
-    PROFILE=release
-  fi
 fi
 
 sed \

--- a/configure.win
+++ b/configure.win
@@ -21,6 +21,13 @@ RUSTC_VERSION="$(rustc --version || true)"
 echo "using Rust package manager: '${CARGO_VERSION}'"
 echo "using Rust compiler: '${RUSTC_VERSION}'"
 
+# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
+if [ "${DEBUG}" = "true" ]; then
+  FEATURES="--features use_winit --features tracing"
+else
+  FEATURES="--features use_winit"
+fi
+
 # In order to use rust-cache action, target dir needs to be a fixed, existing path.
 if [ -d "${GITHUB_WORKSPACE}" ]; then
   CARGO_TARGET_DIR=$(echo "${GITHUB_WORKSPACE}/src/rust/target" | sed -e 's|\\|/|g') # normalize path
@@ -36,11 +43,9 @@ else
   fi
 fi
 
-FEATURES="--features use_winit"
-
 sed \
   -e "s/@TARGET@/x86_64-pc-windows-gnu/" \
-  -e "s/@FEATURES@/${FEATURES}/" \
   -e "s/@PROFILE@/${PROFILE}/" \
+  -e "s/@FEATURES@/${FEATURES}/" \
   -e "s|@CARGO_TARGET_DIR@|${CARGO_TARGET_DIR}|" \
   src/Makevars.win.in > src/Makevars.win

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,9 +1,7 @@
 TARGET = @TARGET@
 
-# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
-PROFILE = $(subst x,release,$(subst truex,dev,$(DEBUG)x))
-TRACING = $(subst x,,$(subst truex,--features tracing,$(DEBUG)x))
-FEATURES = @FEATURES@ $(TRACING)
+PROFILE = @PROFILE@
+FEATURES = @FEATURES@
 
 TARGET_DIR = @CARGO_TARGET_DIR@
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -1,9 +1,7 @@
 TARGET = @TARGET@
 
-# catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
 PROFILE = @PROFILE@
-TRACING = $(subst x,,$(subst truex,--features tracing,$(DEBUG)x))
-FEATURES = @FEATURES@ $(TRACING)
+FEATURES = @FEATURES@
 
 TARGET_DIR = @CARGO_TARGET_DIR@
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -1,7 +1,7 @@
 TARGET = @TARGET@
 
 # catch DEBUG envvar, which is passed from pkgbuild::compile_dll()
-PROFILE = $(subst x,release,$(subst truex,dev,$(DEBUG)x))
+PROFILE = @PROFILE@
 TRACING = $(subst x,,$(subst truex,--features tracing,$(DEBUG)x))
 FEATURES = @FEATURES@ $(TRACING)
 


### PR DESCRIPTION
For some reason, Windows runner ignores rust-cache. So, let's give up caching and always compile with the dev profile, which should be faster. (If the artifacts are to be cached, release profile is better for size, but this is the case when the compile time is more important)

cf. https://yutani.rbind.io/post/rust-cache-and-r/